### PR TITLE
Adjust headers for mobile and clean menu

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Header />
-      <main className="pt-20 min-h-screen bg-warm-white">
+      <main className="pt-24 min-h-screen bg-warm-white">
         {children}
       </main>
       <Footer />

--- a/pages/menu.tsx
+++ b/pages/menu.tsx
@@ -146,24 +146,7 @@ export default function MenuPage() {
         </p>
       </div>
 
-      {/* Special Items */}
-      <div className="bg-gradient-to-r from-red-50 to-orange-50 p-8 rounded-lg border border-red-200 mb-12">
-        <h2 className="text-2xl font-bold mb-6 text-center">This Week's Specials</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-white p-6 rounded-lg shadow-sm text-center">
-            <h3 className="font-bold text-lg text-red-600 mb-2">Burger Of The Week</h3>
-            <p className="text-gray-800 font-semibold">The Drunken Mushroom</p>
-          </div>
-          <div className="bg-white p-6 rounded-lg shadow-sm text-center">
-            <h3 className="font-bold text-lg text-red-600 mb-2">Dessert</h3>
-            <p className="text-gray-800 font-semibold">Robert's Heat-Beatin', Life-Affirmin' Key Lime Pie</p>
-          </div>
-          <div className="bg-white p-6 rounded-lg shadow-sm text-center">
-            <h3 className="font-bold text-lg text-red-600 mb-2">Draft Cocktail</h3>
-            <p className="text-gray-800 font-semibold">The Gin-Gin Negroni</p>
-          </div>
-        </div>
-      </div>
+      {/* Specials section removed per request */}
       
       {/* Food Menu */}
       {foodCategories.map(category => {


### PR DESCRIPTION
Increase main content top padding to prevent headers from being cut off on mobile and remove the specials section from the menu page.

---
<a href="https://cursor.com/background-agent?bcId=bc-30c329d2-3e07-4f0d-8e43-a40de32e8003">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30c329d2-3e07-4f0d-8e43-a40de32e8003">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

